### PR TITLE
DM-33242: Explicitly define calibrate_metadata using the old definition

### DIFF
--- a/bin/run_demo.sh
+++ b/bin/run_demo.sh
@@ -48,6 +48,11 @@ if [ -z "$(butler query-datasets DATA_REPO/ raw | grep HSC)" ]; then
     butler define-visits DATA_REPO HSC --collections HSC/raw/all
 fi
 
+# Explicitly define a dataset type that uses the old style metadata definition.
+if [ -z "$(butler query-dataset-types DATA_REPO/ calibrate_metadata | grep -v results)"]; then
+    butler register-dataset-type DATA_REPO calibrate_metadata PropertySet band instrument detector physical_filter visit
+fi
+
 incoll="HSC/calib,HSC/raw/all,refcats"
 
 # Pipeline execution will fail on second attempt because the output run


### PR DESCRIPTION
This will test that repositories using a PropertySet can still
function with modern code that uses TaskMetadata. isr_metadata
will be persisted as JSON TaskMetadata and calibrate_metadata
will be persisted as YAML PropertySet.