### PR TITLE
DM-29904: Update instructions to run in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@ Its main purpose is to check that the pipeline infrastructure is working correct
 To run the example, from the `pipelines_check` root directory do:
 
 ```
-$ source $LSST_HOME/loadLSST.sh
-$ setup -r .
+$ source $LSST_HOME/loadLSST.bash
+$ setup lsst_distrib
+$ setup -j -r .
 $ ./bin/run_demo.sh
 ```
 


### PR DESCRIPTION
- `setup -r .` would only work if the user had previously
   cloned a specific tag as current, which is not part of the
   basic pipelines installation instructions.